### PR TITLE
Changed YAML file apiVersion

### DIFF
--- a/01-pods-deployments.md
+++ b/01-pods-deployments.md
@@ -104,7 +104,7 @@ The contents of `nginx-simple-deployment.yaml` are as follows:
 ```
 $ cat nginx-simple-deployment.yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx


### PR DESCRIPTION
Getting Error when try to use the YAML file. As per the below link by changing the  "apiVersion: apps/v1" has resolve the issue.
Hence changed "apiVersion: extensions/v1beta1" to "apiVersion: apps/v1" in the YAML file

https://github.com/coreos/etcd-operator/issues/2126

Error : - 

PS C:\Users\Samu\.kube> kubectl apply -f "C:\Users\Samu\.kube\nginx-simple-deployment.yaml"
error: unable to recognize "C:\\Users\\Samu\\.kube\\nginx-simple-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"

PS C:\Users\Samu\.kube> kubectl version
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.8", GitCommit:"211047e9a1922595eaa3a1127ed365e9299a6c23", GitTreeState:"clean", BuildDate:"2019-10-15T12:11:03Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"windows/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-07T21:12:17Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}